### PR TITLE
Player color in color shape

### DIFF
--- a/tts/Color.def.lua
+++ b/tts/Color.def.lua
@@ -13,7 +13,7 @@
 ---@alias tts__ColorShape tts__CharColorShape | tts__NumColorShape | tts__PlayerColor
 
 ---@class tts__Color
----@overload fun(src: tts__Color): tts__Color
+---@overload fun(src: tts__Color | tts__NumColorShape | tts__CharColorShape): tts__Color
 ---@overload fun(r: number, g: number, b: number): tts__Color
 ---@overload fun(r: number, g: number, b: number, a: number): tts__Color
 ---@field [tts__PlayerColor] tts__Color

--- a/tts/Color.def.lua
+++ b/tts/Color.def.lua
@@ -10,7 +10,7 @@
 ---@field [3] number
 ---@field [4] nil | number
 
----@alias tts__ColorShape tts__CharColorShape | tts__NumColorShape
+---@alias tts__ColorShape tts__CharColorShape | tts__NumColorShape | tts__PlayerColor
 
 ---@class tts__Color
 ---@overload fun(src: tts__Color): tts__Color


### PR DESCRIPTION
Unfortunately we can't simply make Color accept the new `tts__ColorShape` because it doesn't accept player colors, but I've opened another pr to that effect [here](https://github.com/Berserk-Games/Tabletop-Simulator-Lua-Classes/pull/5).